### PR TITLE
Update CUDA workflow to not use github cache

### DIFF
--- a/.github/workflows/ci-with-cuda.yml
+++ b/.github/workflows/ci-with-cuda.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Setup CUDA Toolkit
         uses: Jimver/cuda-toolkit@v0.2.26
         id: cuda-toolkit
+        use-github-cache: false
         with:
           cuda: '12.8.0'
           log-file-suffix: '${{matrix.toolchain}}.txt'


### PR DESCRIPTION
This eliminates the flaky nature of the workflow where the action runs out of disk space.