### PR TITLE
Add step to free up disk space in CUDA workflow

### DIFF
--- a/.github/workflows/ci-with-cuda.yml
+++ b/.github/workflows/ci-with-cuda.yml
@@ -24,6 +24,20 @@ jobs:
             compiler: nvcc
 
     steps:
+      - name: Free Disk Space Before Build
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/lib/android/sdk/ndk
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo apt-get clean
+          echo "Disk space after cleanup:"
+          df -h
+
       - name: Setup CUDA Toolkit
         uses: Jimver/cuda-toolkit@v0.2.26
         id: cuda-toolkit
@@ -31,6 +45,7 @@ jobs:
           cuda: '12.8.0'
           log-file-suffix: '${{matrix.toolchain}}.txt'
           use-github-cache: false
+
       - name: Checkout Code
         uses: actions/checkout@v2
 


### PR DESCRIPTION
This pull request introduces a new step in the CI workflow to free up disk space before the build process. This change is aimed at ensuring sufficient resources for subsequent steps, particularly in environments with limited storage.

### CI workflow improvement:
* [`.github/workflows/ci-with-cuda.yml`](diffhunk://#diff-03509cc749d7ac9c15334fc4901612a5053a6db9f96b34f85e24a87323bbb71aR27-R48): Added a step named "Free Disk Space Before Build" to clean up unnecessary files and directories, such as `ghcup`, `CodeQL`, Android SDK NDK, .NET, and others. This step also includes commands to display disk usage before and after the cleanup.

Fixes #16 