### PR TITLE
Add unit tests for the homography algorithm

### DIFF
--- a/.github/workflows/ci-with-cuda.yml
+++ b/.github/workflows/ci-with-cuda.yml
@@ -27,13 +27,13 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
 
-      #      - name: Cache build
-      #        uses: actions/cache@v4
-      #        with:
-      #          path: build/
-      #          key: ${{ runner.os }}-build-${{ hashFiles('**/CMakeLists.txt') }}
-      #          restore-keys: |
-      #            ${{ runner.os }}-build-
+      - name: Cache build
+        uses: actions/cache@v4
+        with:
+          path: build/
+          key: ${{ runner.os }}-build-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-build- 
 
       - name: Configure (${{ matrix.configuration }})
         run: |

--- a/.github/workflows/ci-with-cuda.yml
+++ b/.github/workflows/ci-with-cuda.yml
@@ -8,7 +8,7 @@ jobs:
   build-and-test:
 
     name: ${{ matrix.toolchain }}
-    runs-on: ${{ matrix.os }}
+    runs-on: self-hosted
 
     strategy:
       matrix:
@@ -24,13 +24,6 @@ jobs:
             compiler: nvcc
 
     steps:
-      - name: Setup CUDA Toolkit
-        uses: Jimver/cuda-toolkit@v0.2.26
-        id: cuda-toolkit
-        with:
-          cuda: '12.8.0'
-          log-file-suffix: '${{matrix.toolchain}}.txt'
-          use-github-cache: false
       - name: Checkout Code
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci-with-cuda.yml
+++ b/.github/workflows/ci-with-cuda.yml
@@ -27,13 +27,13 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
 
-      - name: Cache build
-        uses: actions/cache@v4
-        with:
-          path: build/
-          key: ${{ runner.os }}-build-${{ hashFiles('**/CMakeLists.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-build- 
+      #      - name: Cache build
+      #        uses: actions/cache@v4
+      #        with:
+      #          path: build/
+      #          key: ${{ runner.os }}-build-${{ hashFiles('**/CMakeLists.txt') }}
+      #          restore-keys: |
+      #            ${{ runner.os }}-build-
 
       - name: Configure (${{ matrix.configuration }})
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ endif ()
 # --------------------------------------------------------------------------------
 set(SOURCES          # All .cpp files in src/
         src/algorithms/cpu_homographer.cpp
-        src/algorithms/base_homographer.cpp
+        src/algorithms/abstract_homographer.cpp
 )
 if(ENABLE_CUDA)
     list(APPEND SOURCES src/algorithms/cuda_homographer.cu)

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -56,8 +56,9 @@ int run_homography(const std::string& imagePath, std::vector<int>& sourceCoords,
         }
     }
 
-    PointArray source{};
-    PointArray destination{};
+    std::array<std::array<int, AbstractHomographer::HOMOGRAPHY_2D_COORDS_SIZE>, AbstractHomographer::NUM_2D_COORDS> source{};
+    std::array<std::array<int, AbstractHomographer::HOMOGRAPHY_2D_COORDS_SIZE>, AbstractHomographer::NUM_2D_COORDS>
+        destination{};
 
     for (size_t i = 0; i < 4; ++i) {
         source[i][0] = sourceCoords[2 * i];

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -56,9 +56,8 @@ int run_homography(const std::string& imagePath, std::vector<int>& sourceCoords,
         }
     }
 
-    std::array<std::array<int, AbstractHomographer::HOMOGRAPHY_2D_COORDS_SIZE>, AbstractHomographer::NUM_2D_COORDS> source{};
-    std::array<std::array<int, AbstractHomographer::HOMOGRAPHY_2D_COORDS_SIZE>, AbstractHomographer::NUM_2D_COORDS>
-        destination{};
+    PointArray source{};
+    PointArray destination{};
 
     for (size_t i = 0; i < 4; ++i) {
         source[i][0] = sourceCoords[2 * i];

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -86,8 +86,7 @@ function(setup_target_for_coverage _targetname _testrunner _outputname)
 	
 	# Show info where to find the report
 	add_custom_command(TARGET ${_targetname} POST_BUILD
-		COMMAND ;
-        COMMENT "${BoldMagenta}Open ./${_outputname}/index.html in your browser to view the coverage report.${ColourReset}"
+	    COMMAND ${CMAKE_COMMAND} -E echo "${BoldMagenta}Open ./${_outputname}/index.html in your browser to view the coverage report.${ColourReset}"
 	)
 
 endfunction() # setup_target_for_coverage

--- a/include/algorithms/abstract_homographer.h
+++ b/include/algorithms/abstract_homographer.h
@@ -9,20 +9,20 @@ using namespace std;
 /**
  * @brief Provides methods for homography computation and backward mapping.
  *
- * The Homographer class offers static methods to:
+ * The AbstractHomographer class offers static methods to:
  * - Calculate a 3x3 homography matrix from four 2D source and destination point
  * pairs.
  * - Apply backward mapping to transform an image using a given homography
  * matrix.
  */
-class Homographer {
+class AbstractHomographer {
 public:
     static constexpr int HOMOGRAPHY_SIZE = 3 * 3;
     static constexpr int HOMOGRAPHY_2D_COORDS_SIZE = 2;
     static constexpr int NUM_2D_COORDS = 4;
 
-    virtual ~Homographer() = default;
-    Homographer() = default;
+    virtual ~AbstractHomographer() = default;
+    AbstractHomographer() = default;
     /**
     * @brief Calculates the 3x3 homography matrix that maps four source points
     * to four destination points.

--- a/include/algorithms/cpu_homographer.h
+++ b/include/algorithms/cpu_homographer.h
@@ -1,7 +1,7 @@
 #pragma once
-#include <algorithms/base_homographer.h>
+#include <algorithms/abstract_homographer.h>
 
-class CPUHomographer : public Homographer {
+class CPUHomographer : public AbstractHomographer {
 protected:
     void transformCoordinates(cv::Mat homogeneousCoordinates, cv::Mat inverseTransform,
                               cv::Mat transformedCoordinates) override;

--- a/include/algorithms/cuda_homographer.cuh
+++ b/include/algorithms/cuda_homographer.cuh
@@ -1,8 +1,8 @@
 #pragma once
-#include <algorithms/base_homographer.h>
+#include <algorithms/abstract_homographer.h>
 #include <cublas_v2.h>
 
-class CUDAHomographer : public Homographer {
+class CUDAHomographer : public AbstractHomographer {
 public:
     CUDAHomographer();
     ~CUDAHomographer();

--- a/include/constants.h
+++ b/include/constants.h
@@ -1,8 +1,9 @@
 #pragma once
+#include <vector>
 
 namespace DefaultConstants {
 
-const std::vector DEFAULT_HOMOGRAPHY_SOURCE_COORDS = { 0, 0, 1, 0, 1, 1, 0, 1 };
-const std::vector DEFAULT_HOMOGRAPHY_DESTINATION_COORDS = { 0, 0, 2, 0, 2, 2, 0, 2 };
+const std::vector DEFAULT_HOMOGRAPHY_SOURCE_COORDS = {0, 0, 1, 0, 1, 1, 0, 1};
+const std::vector DEFAULT_HOMOGRAPHY_DESTINATION_COORDS = {0, 0, 2, 0, 2, 2, 0, 2};
 
 } // namespace DefaultConstants

--- a/src/algorithms/abstract_homographer.cpp
+++ b/src/algorithms/abstract_homographer.cpp
@@ -1,8 +1,8 @@
-#include <algorithms/base_homographer.h>
+#include <algorithms/abstract_homographer.h>
 
-array<float, Homographer::HOMOGRAPHY_SIZE>
-Homographer::calculateHomography(const array<array<int, HOMOGRAPHY_2D_COORDS_SIZE>, NUM_2D_COORDS>& source,
-                                 const array<array<int, HOMOGRAPHY_2D_COORDS_SIZE>, NUM_2D_COORDS>& destination) {
+array<float, AbstractHomographer::HOMOGRAPHY_SIZE>
+AbstractHomographer::calculateHomography(const array<array<int, HOMOGRAPHY_2D_COORDS_SIZE>, NUM_2D_COORDS>& source,
+                                         const array<array<int, HOMOGRAPHY_2D_COORDS_SIZE>, NUM_2D_COORDS>& destination) {
     const array<float, 64> equationMatrix = {-static_cast<float>(source[0][0]),
                                              -static_cast<float>(source[0][1]),
                                              -1.0f,
@@ -92,8 +92,8 @@ Homographer::calculateHomography(const array<array<int, HOMOGRAPHY_2D_COORDS_SIZ
     return homography;
 }
 
-void Homographer::backwardMap(const array<float, HOMOGRAPHY_SIZE>& homography, cv::Mat& sourceImage,
-                              cv::Mat& outputImage) {
+void AbstractHomographer::backwardMap(const array<float, HOMOGRAPHY_SIZE>& homography, cv::Mat& sourceImage,
+                                      cv::Mat& outputImage) {
     int height = sourceImage.rows;
     int width = sourceImage.cols;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.31)
 # List all files containing tests. (Change as needed)
 set(TESTFILES        # All .cpp files in tests/
     main.cpp
+    algorithms/test_homographer.cpp
 )
 
 set(TEST_MAIN unit_tests)   # Default name for test executable (change if you wish).

--- a/tests/algorithms/test_homographer.cpp
+++ b/tests/algorithms/test_homographer.cpp
@@ -1,13 +1,27 @@
 #include "constants.h"
 #include <algorithms/cpu_homographer.h>
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #ifdef USE_CUDA
 #    include <algorithms/cuda_homographer.cuh>
 #endif
 
-TEST_CASE("Test CPUHomographer") {
-    CPUHomographer homographer = CPUHomographer();
+template <typename T>
+struct HomographerFixture {
+    T homographer;
 
+    HomographerFixture() : homographer() {}
+};
+
+using MyTypes = std::tuple<CPUHomographer
+#ifdef USE_CUDA
+                           ,
+                           CUDAHomographer
+#endif
+                           >;
+
+TEMPLATE_LIST_TEST_CASE_METHOD(HomographerFixture, "Test Homographer", "[class][template][list]", MyTypes) {
+    auto homographer = HomographerFixture<CPUHomographer>().homographer;
     SECTION("test calculateHomography") {
         std::array<std::array<int, AbstractHomographer::HOMOGRAPHY_2D_COORDS_SIZE>, AbstractHomographer::NUM_2D_COORDS>
             source{};
@@ -74,48 +88,3 @@ TEST_CASE("Test CPUHomographer") {
         }
     }
 }
-
-#ifdef USE_CUDA
-TEST_CASE("Test CUDAHomographer") {
-    CUDAHomographer homographer = CUDAHomographer();
-
-    SECTION("test backwardMap") {
-        std::array<std::array<int, AbstractHomographer::HOMOGRAPHY_2D_COORDS_SIZE>, AbstractHomographer::NUM_2D_COORDS>
-            source{};
-        std::array<std::array<int, AbstractHomographer::HOMOGRAPHY_2D_COORDS_SIZE>, AbstractHomographer::NUM_2D_COORDS>
-            destination{};
-
-        for (size_t i = 0; i < 4; ++i) {
-            source[i][0] = DefaultConstants::DEFAULT_HOMOGRAPHY_SOURCE_COORDS[2 * i];
-            source[i][1] = DefaultConstants::DEFAULT_HOMOGRAPHY_SOURCE_COORDS[2 * i + 1];
-            destination[i][0] = DefaultConstants::DEFAULT_HOMOGRAPHY_DESTINATION_COORDS[2 * i];
-            destination[i][1] = DefaultConstants::DEFAULT_HOMOGRAPHY_DESTINATION_COORDS[2 * i + 1];
-        }
-
-        auto homography = homographer.calculateHomography(source, destination);
-
-        cv::Mat sourceImage = cv::Mat(100, 100, CV_8UC3, cv::Scalar(255, 0, 0));
-        cv::Mat outputImage;
-
-        for (int i = 0; i < 100; ++i) {
-            for (int j = 0; j < 100; ++j) {
-                if (i <= 50 && j <= 50) {
-                    sourceImage.at<cv::Vec3b>(i, j) = cv::Vec3b(0, 255, 0);
-                }
-            }
-        }
-
-        homographer.backwardMap(homography, sourceImage, outputImage);
-
-        CHECK(outputImage.rows == 100);
-        CHECK(outputImage.cols == 100);
-
-        for (int i = 0; i < outputImage.rows; ++i) {
-            for (int j = 0; j < outputImage.cols; ++j) {
-                cv::Vec3b pixel = outputImage.at<cv::Vec3b>(i, j);
-                CHECK(pixel == cv::Vec3b(0, 255, 0));
-            }
-        }
-    }
-}
-#endif // USE_CUDA

--- a/tests/algorithms/test_homographer.cpp
+++ b/tests/algorithms/test_homographer.cpp
@@ -2,7 +2,7 @@
 #include <algorithms/cpu_homographer.h>
 #include <catch2/catch_test_macros.hpp>
 #ifdef USE_CUDA
-#    include "algorithms/cuda_homographer.cuh"
+#    include <algorithms/cuda_homographer.cuh>
 #endif
 
 TEST_CASE("Test CPUHomographer") {

--- a/tests/algorithms/test_homographer.cpp
+++ b/tests/algorithms/test_homographer.cpp
@@ -1,7 +1,8 @@
-#include "constants.h"
 #include <algorithms/cpu_homographer.h>
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <constants.h>
 #ifdef USE_CUDA
 #    include <algorithms/cuda_homographer.cuh>
 #endif
@@ -38,15 +39,15 @@ TEMPLATE_LIST_TEST_CASE_METHOD(HomographerFixture, "Test Homographer", "[class][
         auto homography = homographer.calculateHomography(source, destination);
 
         CHECK(homography.size() == AbstractHomographer::HOMOGRAPHY_SIZE);
-        CHECK(homography[0] == Approx(2.0f));
-        CHECK(homography[1] == Approx(0.0f));
-        CHECK(homography[2] == Approx(0.0f));
-        CHECK(homography[3] == Approx(0.0f));
-        CHECK(homography[4] == Approx(2.0f));
-        CHECK(homography[5] == Approx(0.0f));
-        CHECK(homography[6] == Approx(0.0f));
-        CHECK(homography[7] == Approx(0.0f));
-        CHECK(homography[8] == Approx(1.0f));
+        CHECK(homography[0] == Catch::Approx(2.0f));
+        CHECK(homography[1] == Catch::Approx(0.0f));
+        CHECK(homography[2] == Catch::Approx(0.0f));
+        CHECK(homography[3] == Catch::Approx(0.0f));
+        CHECK(homography[4] == Catch::Approx(2.0f));
+        CHECK(homography[5] == Catch::Approx(0.0f));
+        CHECK(homography[6] == Catch::Approx(0.0f));
+        CHECK(homography[7] == Catch::Approx(0.0f));
+        CHECK(homography[8] == Catch::Approx(1.0f));
     }
 
     SECTION("test backwardMap") {

--- a/tests/algorithms/test_homographer.cpp
+++ b/tests/algorithms/test_homographer.cpp
@@ -24,15 +24,15 @@ TEST_CASE("Test CPUHomographer") {
         auto homography = homographer.calculateHomography(source, destination);
 
         CHECK(homography.size() == AbstractHomographer::HOMOGRAPHY_SIZE);
-        CHECK(homography[0] == 2.0f);
-        CHECK(homography[1] == 0.0f);
-        CHECK(homography[2] == 0.0f);
-        CHECK(homography[3] == 0.0f);
-        CHECK(homography[4] == 2.0f);
-        CHECK(homography[5] == 0.0f);
-        CHECK(homography[6] == 0.0f);
-        CHECK(homography[7] == 0.0f);
-        CHECK(homography[8] == 1.0f);
+        CHECK(homography[0] == Approx(2.0f));
+        CHECK(homography[1] == Approx(0.0f));
+        CHECK(homography[2] == Approx(0.0f));
+        CHECK(homography[3] == Approx(0.0f));
+        CHECK(homography[4] == Approx(2.0f));
+        CHECK(homography[5] == Approx(0.0f));
+        CHECK(homography[6] == Approx(0.0f));
+        CHECK(homography[7] == Approx(0.0f));
+        CHECK(homography[8] == Approx(1.0f));
     }
 
     SECTION("test backwardMap") {

--- a/tests/algorithms/test_homographer.cpp
+++ b/tests/algorithms/test_homographer.cpp
@@ -1,0 +1,121 @@
+#include "constants.h"
+#include <algorithms/cpu_homographer.h>
+#include <catch2/catch_test_macros.hpp>
+#ifdef USE_CUDA
+#    include "algorithms/cuda_homographer.cuh"
+#endif
+
+TEST_CASE("Test CPUHomographer") {
+    CPUHomographer homographer = CPUHomographer();
+
+    SECTION("test calculateHomography") {
+        std::array<std::array<int, AbstractHomographer::HOMOGRAPHY_2D_COORDS_SIZE>, AbstractHomographer::NUM_2D_COORDS>
+            source{};
+        std::array<std::array<int, AbstractHomographer::HOMOGRAPHY_2D_COORDS_SIZE>, AbstractHomographer::NUM_2D_COORDS>
+            destination{};
+
+        for (size_t i = 0; i < 4; ++i) {
+            source[i][0] = DefaultConstants::DEFAULT_HOMOGRAPHY_SOURCE_COORDS[2 * i];
+            source[i][1] = DefaultConstants::DEFAULT_HOMOGRAPHY_SOURCE_COORDS[2 * i + 1];
+            destination[i][0] = DefaultConstants::DEFAULT_HOMOGRAPHY_DESTINATION_COORDS[2 * i];
+            destination[i][1] = DefaultConstants::DEFAULT_HOMOGRAPHY_DESTINATION_COORDS[2 * i + 1];
+        }
+
+        auto homography = homographer.calculateHomography(source, destination);
+
+        CHECK(homography.size() == AbstractHomographer::HOMOGRAPHY_SIZE);
+        CHECK(homography[0] == 2.0f);
+        CHECK(homography[1] == 0.0f);
+        CHECK(homography[2] == 0.0f);
+        CHECK(homography[3] == 0.0f);
+        CHECK(homography[4] == 2.0f);
+        CHECK(homography[5] == 0.0f);
+        CHECK(homography[6] == 0.0f);
+        CHECK(homography[7] == 0.0f);
+        CHECK(homography[8] == 1.0f);
+    }
+
+    SECTION("test backwardMap") {
+        std::array<std::array<int, AbstractHomographer::HOMOGRAPHY_2D_COORDS_SIZE>, AbstractHomographer::NUM_2D_COORDS>
+            source{};
+        std::array<std::array<int, AbstractHomographer::HOMOGRAPHY_2D_COORDS_SIZE>, AbstractHomographer::NUM_2D_COORDS>
+            destination{};
+
+        for (size_t i = 0; i < 4; ++i) {
+            source[i][0] = DefaultConstants::DEFAULT_HOMOGRAPHY_SOURCE_COORDS[2 * i];
+            source[i][1] = DefaultConstants::DEFAULT_HOMOGRAPHY_SOURCE_COORDS[2 * i + 1];
+            destination[i][0] = DefaultConstants::DEFAULT_HOMOGRAPHY_DESTINATION_COORDS[2 * i];
+            destination[i][1] = DefaultConstants::DEFAULT_HOMOGRAPHY_DESTINATION_COORDS[2 * i + 1];
+        }
+
+        auto homography = homographer.calculateHomography(source, destination);
+
+        cv::Mat sourceImage = cv::Mat(100, 100, CV_8UC3, cv::Scalar(255, 0, 0));
+        cv::Mat outputImage;
+
+        for (int i = 0; i < 100; ++i) {
+            for (int j = 0; j < 100; ++j) {
+                if (i <= 50 && j <= 50) {
+                    sourceImage.at<cv::Vec3b>(i, j) = cv::Vec3b(0, 255, 0);
+                }
+            }
+        }
+
+        homographer.backwardMap(homography, sourceImage, outputImage);
+
+        CHECK(outputImage.rows == 100);
+        CHECK(outputImage.cols == 100);
+
+        for (int i = 0; i < outputImage.rows; ++i) {
+            for (int j = 0; j < outputImage.cols; ++j) {
+                cv::Vec3b pixel = outputImage.at<cv::Vec3b>(i, j);
+                CHECK(pixel == cv::Vec3b(0, 255, 0));
+            }
+        }
+    }
+}
+
+#ifdef USE_CUDA
+TEST_CASE("Test CUDAHomographer") {
+    CUDAHomographer homographer = CUDAHomographer();
+
+    SECTION("test backwardMap") {
+        std::array<std::array<int, AbstractHomographer::HOMOGRAPHY_2D_COORDS_SIZE>, AbstractHomographer::NUM_2D_COORDS>
+            source{};
+        std::array<std::array<int, AbstractHomographer::HOMOGRAPHY_2D_COORDS_SIZE>, AbstractHomographer::NUM_2D_COORDS>
+            destination{};
+
+        for (size_t i = 0; i < 4; ++i) {
+            source[i][0] = DefaultConstants::DEFAULT_HOMOGRAPHY_SOURCE_COORDS[2 * i];
+            source[i][1] = DefaultConstants::DEFAULT_HOMOGRAPHY_SOURCE_COORDS[2 * i + 1];
+            destination[i][0] = DefaultConstants::DEFAULT_HOMOGRAPHY_DESTINATION_COORDS[2 * i];
+            destination[i][1] = DefaultConstants::DEFAULT_HOMOGRAPHY_DESTINATION_COORDS[2 * i + 1];
+        }
+
+        auto homography = homographer.calculateHomography(source, destination);
+
+        cv::Mat sourceImage = cv::Mat(100, 100, CV_8UC3, cv::Scalar(255, 0, 0));
+        cv::Mat outputImage;
+
+        for (int i = 0; i < 100; ++i) {
+            for (int j = 0; j < 100; ++j) {
+                if (i <= 50 && j <= 50) {
+                    sourceImage.at<cv::Vec3b>(i, j) = cv::Vec3b(0, 255, 0);
+                }
+            }
+        }
+
+        homographer.backwardMap(homography, sourceImage, outputImage);
+
+        CHECK(outputImage.rows == 100);
+        CHECK(outputImage.cols == 100);
+
+        for (int i = 0; i < outputImage.rows; ++i) {
+            for (int j = 0; j < outputImage.cols; ++j) {
+                cv::Vec3b pixel = outputImage.at<cv::Vec3b>(i, j);
+                CHECK(pixel == cv::Vec3b(0, 255, 0));
+            }
+        }
+    }
+}
+#endif // USE_CUDA


### PR DESCRIPTION

This pull request refactors the homography computation system by introducing an abstract base class (`AbstractHomographer`) and updating the codebase to align with this new design. It also improves test coverage by adding unit tests for homography-related functionality. Below are the most important changes grouped by theme:

### Refactoring and Code Design Improvements:
* Renamed `base_homographer` to `abstract_homographer` and updated all references to reflect the new abstract base class design. This includes changes in `src/algorithms/abstract_homographer.cpp`, `include/algorithms/abstract_homographer.h`, and files that inherit from it (`cpu_homographer` and `cuda_homographer`). [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL70-R70) [[2]](diffhunk://#diff-b078a6886afd9da44ff63204c729d471b5b4408cf05ff955a2ddcd36a6b69f70L12-R25) [[3]](diffhunk://#diff-dce41e6b2de0be018ff2b00c2f09fe841567cc4abce472b4b7042bebadd30f1dL2-R4) [[4]](diffhunk://#diff-9a9c31de63e77ad0c8268afd2d118bf259ab33f9e64ce8e738f2c68e273ca49aL2-R5) [[5]](diffhunk://#diff-0c56eee69845f1845d6490ba62caf78c4a068c521b4275fb36a8fa462a7114aeL1-R4) [[6]](diffhunk://#diff-0c56eee69845f1845d6490ba62caf78c4a068c521b4275fb36a8fa462a7114aeL95-R95)
* Updated the `run_homography` function in `app/main.cpp` to use `AbstractHomographer` and simplified the handling of source and destination coordinates by introducing `PointArray`. [[1]](diffhunk://#diff-c1b709b8a90bef4573ddad8a9b2fbc5d5dbc85e4dc759f95b6d9905931fec24fL60-R60) [[2]](diffhunk://#diff-c1b709b8a90bef4573ddad8a9b2fbc5d5dbc85e4dc759f95b6d9905931fec24fL70-R69) [[3]](diffhunk://#diff-c1b709b8a90bef4573ddad8a9b2fbc5d5dbc85e4dc759f95b6d9905931fec24fL81-R98)

### Code Quality and Namespace Adjustments:
* Removed the `using namespace cv;` directive in `app/main.cpp` and replaced OpenCV calls with fully qualified names (e.g., `cv::Mat`, `cv::imread`). This improves code clarity and avoids potential namespace conflicts. [[1]](diffhunk://#diff-c1b709b8a90bef4573ddad8a9b2fbc5d5dbc85e4dc759f95b6d9905931fec24fL12) [[2]](diffhunk://#diff-c1b709b8a90bef4573ddad8a9b2fbc5d5dbc85e4dc759f95b6d9905931fec24fL81-R98)

### Build System and Coverage Reporting:
* Updated `CMakeLists.txt` to include the renamed `abstract_homographer.cpp` file.
* Fixed a bug in the `CodeCoverage.cmake` script by replacing an empty command with a proper `CMAKE_COMMAND` echo statement for displaying coverage report instructions.

### Testing Enhancements:
* Added a new test file `tests/algorithms/test_homographer.cpp` with parameterized tests for `CPUHomographer` and `CUDAHomographer` (if CUDA is enabled). These tests validate the `calculateHomography` and `backwardMap` methods.
* Included the new test file in the `tests/CMakeLists.txt` configuration.

### Miscellaneous:
* Included `<vector>` in `include/constants.h` to ensure compatibility with the new test cases.

closes #13 